### PR TITLE
Update script.js

### DIFF
--- a/pinterest/script.js
+++ b/pinterest/script.js
@@ -33,6 +33,7 @@ function handleSearchFunctionality(){
     input
     .addEventListener("blur", function(){
         document.querySelector(".overlay").style.display = "none";
+        document.querySelector(".searchdata").style.display = "none"
     })
 
     input


### PR DESCRIPTION
When you input a value in the search field, it displays related items, but when you go back or click elsewhere, the search box doesn't get hidden. So, I just added the 'hidden' property while exiting the search.